### PR TITLE
ユーザー登録時のメアド有効確認、メールアドレス、パスワードの変更APIの実装

### DIFF
--- a/backend-drf/api/accounts/admin.py
+++ b/backend-drf/api/accounts/admin.py
@@ -14,7 +14,7 @@ class UserAdmin(BaseUserAdmin):
     # Userモデルの表示で使用されるフィールド。
     # これらは、auth.User上の特定のフィールドを参照するベースUserAdmin上の定義を上書きします
     ordering = ["id"]
-    list_display = ["email", "username"]
+    list_display = ["email", "username", "is_active"]
     list_filter = ["is_staff", "is_active"]
     fieldsets = [
         (

--- a/backend-drf/api/accounts/authentication.py
+++ b/backend-drf/api/accounts/authentication.py
@@ -10,6 +10,8 @@ class CustomJWTAuthentication(JWTAuthentication):
         request.META["HTTP_AUTHORIZATION"] = "{header_type} {access_token}".format(
             header_type="Bearer", access_token=token
         )
+        if token is None:
+            return None
 
         print(f'access:{token}')
         # refresh = request.COOKIES.get("refresh")

--- a/backend-drf/api/accounts/email.py
+++ b/backend-drf/api/accounts/email.py
@@ -1,0 +1,29 @@
+from django.contrib.auth.tokens import default_token_generator
+from djoser import utils
+from templated_mail.mail import BaseEmailMessage
+from django.conf import settings
+
+
+class EmailManageer(BaseEmailMessage):
+    def send(self, to, *args, **kwargs):
+        self.render()
+        self.to = to
+        self.cc = kwargs.pop('cc', [])
+        self.bcc = kwargs.pop('bcc', [])
+        self.reply_to = kwargs.pop('reply_to', [])
+        self.from_email = kwargs.pop('from_email',
+                                     f'Video-UP <{settings.DEFAULT_FROM_EMAIL}>')
+        super(BaseEmailMessage, self).send(*args, **kwargs)
+
+
+class ActivationEmail(EmailManageer):
+    template_name = 'accounts/activation.html'
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data()
+        user = context.get('user')
+        context['username'] = user.username
+        context['uid'] = utils.encode_uid(user.pk)
+        context['token'] = default_token_generator.make_token(user)
+        context['url'] = settings.DJOSER['ACTIVATION_URL'].format(**context)
+        return context

--- a/backend-drf/api/accounts/email.py
+++ b/backend-drf/api/accounts/email.py
@@ -8,22 +8,79 @@ class EmailManageer(BaseEmailMessage):
     def send(self, to, *args, **kwargs):
         self.render()
         self.to = to
-        self.cc = kwargs.pop('cc', [])
-        self.bcc = kwargs.pop('bcc', [])
-        self.reply_to = kwargs.pop('reply_to', [])
-        self.from_email = kwargs.pop('from_email',
-                                     f'Video-UP <{settings.DEFAULT_FROM_EMAIL}>')
+        self.cc = kwargs.pop("cc", [])
+        self.bcc = kwargs.pop("bcc", [])
+        self.reply_to = kwargs.pop("reply_to", [])
+        self.from_email = kwargs.pop(
+            "from_email", f"Video-UP <{settings.DEFAULT_FROM_EMAIL}>"
+        )
         super(BaseEmailMessage, self).send(*args, **kwargs)
 
 
 class ActivationEmail(EmailManageer):
-    template_name = 'accounts/activation.html'
+    template_name = "accounts/activation.html"
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data()
-        user = context.get('user')
-        context['username'] = user.username
-        context['uid'] = utils.encode_uid(user.pk)
-        context['token'] = default_token_generator.make_token(user)
-        context['url'] = settings.DJOSER['ACTIVATION_URL'].format(**context)
+        user = context.get("user")
+        context["username"] = user.username
+        context["uid"] = utils.encode_uid(user.pk)
+        context["token"] = default_token_generator.make_token(user)
+        context["url"] = settings.DJOSER["ACTIVATION_URL"].format(**context)
+        return context
+
+
+class ConfirmationEmail(EmailManageer):
+    template_name = "accounts/confirmation.html"
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data()
+        user = context.get("user")
+        context["username"] = user.username
+        return context
+
+
+class PasswordResetEmail(EmailManageer):
+    template_name = "accounts/password_reset.html"
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data()
+        user = context.get("user")
+        context["username"] = user.username
+        context["uid"] = utils.encode_uid(user.pk)
+        context["token"] = default_token_generator.make_token(user)
+        context["url"] = settings.DJOSER["PASSWORD_RESET_CONFIRM_URL"].format(**context)
+        return context
+
+
+class UsernameResetEmail(EmailManageer):
+    template_name = "accounts/email_reset.html"
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data()
+        user = context.get("user")
+        context["username"] = user.username
+        context["uid"] = utils.encode_uid(user.pk)
+        context["token"] = default_token_generator.make_token(user)
+        context["url"] = settings.DJOSER["USERNAME_RESET_CONFIRM_URL"].format(**context)
+        return context
+
+
+class PasswordChangedConfirmationEmail(EmailManageer):
+    template_name = "accounts/password_changed_confirmation.html"
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data()
+        user = context.get("user")
+        context["username"] = user.username
+        return context
+
+
+class UsernameChangedConfirmationEmail(EmailManageer):
+    template_name = "accounts/email_changed_confirmation.html"
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data()
+        user = context.get("user")
+        context["username"] = user.username
         return context

--- a/backend-drf/api/accounts/models.py
+++ b/backend-drf/api/accounts/models.py
@@ -4,7 +4,6 @@ from django.contrib.auth.models import (
     AbstractBaseUser,
     BaseUserManager,
     PermissionsMixin,
-
 )
 from django.utils import timezone
 from django.db import models
@@ -25,7 +24,9 @@ class UserManager(BaseUserManager):
         if not email:
             raise ValueError("Email address is must")
 
-        user = self.model(username=username, email=self.normalize_email(email), **extra_fields)
+        user = self.model(
+            username=username, email=self.normalize_email(email), **extra_fields
+        )
         user.set_password(password)
         user.save(using=self._db)
 
@@ -46,11 +47,11 @@ class UserManager(BaseUserManager):
 class User(AbstractBaseUser, PermissionsMixin):
 
     id = models.UUIDField(default=uuid.uuid4, primary_key=True, editable=False)
-    username = models.CharField('会社名', max_length=255, blank=True)
-    email = models.EmailField('メールアドレス', max_length=255, unique=True)
-    is_active = models.BooleanField('有効フラグ', default=True)
-    is_staff = models.BooleanField('管理サイトアクセス権限', default=False)
-    date_joined = models.DateTimeField('登録日時', default=timezone.now)
+    username = models.CharField("会社名", max_length=255, blank=True)
+    email = models.EmailField("メールアドレス", max_length=255, unique=True)
+    is_active = models.BooleanField(default=True)
+    is_staff = models.BooleanField(default=False)
+    date_joined = models.DateTimeField("登録日時", default=timezone.now)
 
     objects = UserManager()
 
@@ -84,12 +85,12 @@ class Profile(models.Model):
     # )
 
     user = models.OneToOneField(User, on_delete=models.CASCADE)
-    company_name = models.CharField('会社名', max_length=255, blank=True)
-    plan = models.IntegerField('プラン', choices=Plan.choices, default=1)
-    occupation = models.CharField('職業', max_length=50, blank=True)
-    address = models.CharField('住所', max_length=255, blank=True)
+    company_name = models.CharField("会社名", max_length=255, blank=True)
+    plan = models.IntegerField("プラン", choices=Plan.choices, default=1)
+    occupation = models.CharField("職業", max_length=50, blank=True)
+    address = models.CharField("住所", max_length=255, blank=True)
     phone = models.CharField("電話番号", max_length=255, blank=True)
-    age = models.CharField('年齢', max_length=255, blank=True)
+    age = models.CharField("年齢", max_length=255, blank=True)
     gendar = models.CharField("性別", max_length=2, choices=GENDER_CHOICES, blank=True)
 
     def __str__(self):
@@ -98,7 +99,7 @@ class Profile(models.Model):
 
 @receiver(post_save, sender=User)
 def create_profile(sender, instance, created, **kwargs):
-    """ User新規作成時にProfileのレコードも作成する """
+    """User新規作成時にProfileのレコードも作成する"""
     if created:
         Profile.objects.get_or_create(user=instance)
 

--- a/backend-drf/api/accounts/serializers.py
+++ b/backend-drf/api/accounts/serializers.py
@@ -1,13 +1,28 @@
+from djoser.serializers import UserCreateSerializer as BaseUserCreateSerializer
 from django.contrib.auth import get_user_model
 from rest_framework import serializers
 from .models import Profile
+
+
+class UserCreateSerializer(BaseUserCreateSerializer):
+
+    class Meta(BaseUserCreateSerializer.Meta):
+        model = get_user_model()
+        fields = ("email", "password", "username", "id")
+        # extra_kwargs = {"password": {"write_only": True, "min_length": 6}}
+
+    def create(self, validated_data):
+
+        user = super().create(validated_data)
+
+        return user
 
 
 class UserSerializer(serializers.ModelSerializer):
     class Meta:
         model = get_user_model()
         fields = ("email", "password", "username", "id")
-        extra_kwargs = {"password": {"write_only": True, "min_length": 6}}
+        # extra_kwargs = {"password": {"write_only": True, "min_length": 6}}
 
     def create(self, validated_data):
         user = get_user_model().objects.create_user(**validated_data)

--- a/backend-drf/api/accounts/templates/accounts/activation.html
+++ b/backend-drf/api/accounts/templates/accounts/activation.html
@@ -1,0 +1,18 @@
+{% block subject %}
+Video-UP 本登録のご案内
+{% endblock subject %}
+
+{% block text_body %}
+{{username}}様
+
+Video-UPにご登録いただき、ありがとうございます。
+
+以下のリンクから本登録を完了してください。
+{{ protocol }}://{{ domain }}/{{ url|safe }}
+
+
+***********************************
+発行元：Video-UP
+***********************************
+
+{% endblock text_body %}

--- a/backend-drf/api/accounts/templates/accounts/confirmation.html
+++ b/backend-drf/api/accounts/templates/accounts/confirmation.html
@@ -1,0 +1,17 @@
+{% block subject %}
+Video-UP 本登録完了のご案内
+{% endblock subject %}
+
+{% block text_body %}
+{{username}}様
+
+Video-UPにご登録いただき、ありがとうございます。
+
+本登録が完了しました。
+
+
+***********************************
+発行元 : Video-UP
+***********************************
+
+{% endblock text_body %}

--- a/backend-drf/api/accounts/templates/accounts/email_changed_confirmation.html
+++ b/backend-drf/api/accounts/templates/accounts/email_changed_confirmation.html
@@ -1,0 +1,17 @@
+{% block subject %}
+Video-UP メールアドレス変更完了のご案内
+{% endblock subject %}
+
+{% block text_body %}
+{{username}}様
+
+Video-UPをご利用いただき、ありがとうございます。
+
+メールアドレスの変更が完了しました。
+
+
+***********************************
+発行元 : Video-UP
+***********************************
+
+{% endblock text_body %}

--- a/backend-drf/api/accounts/templates/accounts/email_reset.html
+++ b/backend-drf/api/accounts/templates/accounts/email_reset.html
@@ -1,0 +1,19 @@
+{% block subject %}
+Video-UP メールアドレスリセット
+{% endblock subject %}
+
+{% block text_body %}
+{{username}}様
+
+Video-UPをご利用いただき、ありがとうございます。
+メールアドレスリセットのリクエストが行われました。
+
+以下のリンクからメールアドレスの再設定を行ってください。
+{{ protocol }}://{{ domain }}/{{ url|safe }}
+
+
+***********************************
+発行元 : Video-UP
+***********************************
+
+{% endblock text_body %}

--- a/backend-drf/api/accounts/templates/accounts/password_changed_confirmation.html
+++ b/backend-drf/api/accounts/templates/accounts/password_changed_confirmation.html
@@ -1,0 +1,17 @@
+{% block subject %}
+Video-UP パスワード変更完了のご案内
+{% endblock subject %}
+
+{% block text_body %}
+{{username}}様
+
+Video-UPをご利用いただき、ありがとうございます。
+
+パスワードの変更が完了しました。
+
+
+***********************************
+発行元 : Video-UP
+***********************************
+
+{% endblock text_body %}

--- a/backend-drf/api/accounts/templates/accounts/password_reset.html
+++ b/backend-drf/api/accounts/templates/accounts/password_reset.html
@@ -1,0 +1,19 @@
+{% block subject %}
+Video-UP パスワードリセット
+{% endblock subject %}
+
+{% block text_body %}
+{{username}}様
+
+Video-UPをご利用いただき、ありがとうございます。
+パスワードリセットのリクエストが行われました。
+
+以下のリンクからパスワードの再設定を行ってください。
+{{ protocol }}://{{ domain }}/{{ url|safe }}
+
+
+***********************************
+発行元 : Video-UP
+***********************************
+
+{% endblock text_body %}

--- a/backend-drf/config/settings/settings.py
+++ b/backend-drf/config/settings/settings.py
@@ -176,11 +176,11 @@ DJOSER = {
 
     'EMAIL': {
         'activation': 'api.accounts.email.ActivationEmail',
-        'confirmation': 'djoser.email.ConfirmationEmail',
-        'password_reset': 'djoser.email.PasswordResetEmail',
-        'password_changed_confirmation': 'djoser.email.PasswordChangedConfirmationEmail',
-        'username_changed_confirmation': 'djoser.email.UsernameChangedConfirmationEmail',
-        'username_reset': 'djoser.email.UsernameResetEmail',
+        'confirmation': 'api.accounts.email.ConfirmationEmail',
+        'password_reset': 'api.accounts.email.PasswordResetEmail',
+        'username_reset': 'api.accounts.email.UsernameResetEmail',
+        'password_changed_confirmation': 'api.accounts.email.PasswordChangedConfirmationEmail',
+        'username_changed_confirmation': 'api.accounts.email.UsernameChangedConfirmationEmail',
     },
 
 }

--- a/backend-drf/config/settings/settings.py
+++ b/backend-drf/config/settings/settings.py
@@ -175,7 +175,7 @@ DJOSER = {
     },
 
     'EMAIL': {
-        'activation': 'djoser.email.ActivationEmail',
+        'activation': 'api.accounts.email.ActivationEmail',
         'confirmation': 'djoser.email.ConfirmationEmail',
         'password_reset': 'djoser.email.PasswordResetEmail',
         'password_changed_confirmation': 'djoser.email.PasswordChangedConfirmationEmail',
@@ -196,7 +196,7 @@ EMAIL_HOST_USER = 'xxx@gmail.com'
 EMAIL_HOST_PASSWORD = 'xxx'
 EMAIL_PORT = 587
 EMAIL_USE_TLS = True
-DEFAULT_FROM_EMAIL = 'xxx@gmail.com'
+DEFAULT_FROM_EMAIL = 'xxx@video-up.com'
 
 
 LOGGING = {

--- a/backend-drf/config/settings/settings.py
+++ b/backend-drf/config/settings/settings.py
@@ -155,15 +155,36 @@ SIMPLE_JWT = {
 }
 
 DJOSER = {
-    # カスタムユーザー用シリアライザー
+
+    'LOGIN_FIELD': 'email',
+    'SEND_ACTIVATION_EMAIL': False,
+    'SEND_CONFIRMATION_EMAIL': False,
+    'PASSWORD_CHANGED_EMAIL_CONFIRMATION': True,
+    'USERNAME_CHANGED_EMAIL_CONFIRMATION': True,
+    'ACTIVATION_URL': 'activate/{uid}/{token}',
+    'USER_CREATE_PASSWORD_RETYPE': True,
+    'SET_USERNAME_RETYPE': True,
+    'SET_PASSWORD_RETYPE': True,
+    'USERNAME_RESET_CONFIRM_URL': 'email/reset/confirm/{uid}/{token}',
+    'PASSWORD_RESET_CONFIRM_URL': 'password/reset/confirm/{uid}/{token}',
+
     "SERIALIZERS": {
         "user_create": "api.accounts.serializers.UserSerializer",
         "user": "api.accounts.serializers.UserSerializer",
         "current_user": "api.accounts.serializers.UserSerializer",
     },
+
+    'EMAIL': {
+        'activation': 'djoser.email.ActivationEmail',
+        'confirmation': 'djoser.email.ConfirmationEmail',
+        'password_reset': 'djoser.email.PasswordResetEmail',
+        'password_changed_confirmation': 'djoser.email.PasswordChangedConfirmationEmail',
+        'username_changed_confirmation': 'djoser.email.UsernameChangedConfirmationEmail',
+        'username_reset': 'djoser.email.UsernameResetEmail',
+    },
+
 }
 
-COOKIE_TIME = 60 * 60 * 12
 
 LOGGING = {
     "version": 1,

--- a/backend-drf/config/settings/settings.py
+++ b/backend-drf/config/settings/settings.py
@@ -157,12 +157,12 @@ SIMPLE_JWT = {
 DJOSER = {
 
     'LOGIN_FIELD': 'email',
-    'SEND_ACTIVATION_EMAIL': False,
-    'SEND_CONFIRMATION_EMAIL': False,
+    'SEND_ACTIVATION_EMAIL': True,
+    'ACTIVATION_URL': 'activate/{uid}/{token}',
+    'SEND_CONFIRMATION_EMAIL': True,
     'PASSWORD_CHANGED_EMAIL_CONFIRMATION': True,
     'USERNAME_CHANGED_EMAIL_CONFIRMATION': True,
-    'ACTIVATION_URL': 'activate/{uid}/{token}',
-    'USER_CREATE_PASSWORD_RETYPE': True,
+    'USER_CREATE_PASSWORD_RETYPE': False,
     'SET_USERNAME_RETYPE': True,
     'SET_PASSWORD_RETYPE': True,
     'USERNAME_RESET_CONFIRM_URL': 'email/reset/confirm/{uid}/{token}',
@@ -184,6 +184,19 @@ DJOSER = {
     },
 
 }
+
+
+# ローカル確認用
+EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
+
+# 本番環境用
+# EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
+EMAIL_HOST = 'smtp.gmail.com'
+EMAIL_HOST_USER = 'xxx@gmail.com'
+EMAIL_HOST_PASSWORD = 'xxx'
+EMAIL_PORT = 587
+EMAIL_USE_TLS = True
+DEFAULT_FROM_EMAIL = 'xxx@gmail.com'
 
 
 LOGGING = {

--- a/backend-drf/config/settings/settings.py
+++ b/backend-drf/config/settings/settings.py
@@ -148,55 +148,48 @@ REST_FRAMEWORK = {
 SIMPLE_JWT = {
     "AUTH_HEADER_TYPES": ("Bearer",),
     "ACCESS_TOKEN_LIFETIME": timedelta(hours=1),
-    'REFRESH_TOKEN_LIFETIME': timedelta(days=1),
-    'AUTH_TOKEN_CLASSES': (
-        'rest_framework_simplejwt.tokens.AccessToken',
-    ),
+    "REFRESH_TOKEN_LIFETIME": timedelta(days=1),
+    "AUTH_TOKEN_CLASSES": ("rest_framework_simplejwt.tokens.AccessToken",),
 }
 
 DJOSER = {
-
-    'LOGIN_FIELD': 'email',
-    'SEND_ACTIVATION_EMAIL': True,
-    'ACTIVATION_URL': 'activate/{uid}/{token}',
-    'SEND_CONFIRMATION_EMAIL': True,
-    'PASSWORD_CHANGED_EMAIL_CONFIRMATION': True,
-    'USERNAME_CHANGED_EMAIL_CONFIRMATION': True,
-    'USER_CREATE_PASSWORD_RETYPE': False,
-    'SET_USERNAME_RETYPE': True,
-    'SET_PASSWORD_RETYPE': True,
-    'USERNAME_RESET_CONFIRM_URL': 'email/reset/confirm/{uid}/{token}',
-    'PASSWORD_RESET_CONFIRM_URL': 'password/reset/confirm/{uid}/{token}',
-
+    "LOGIN_FIELD": "email",
+    "SEND_ACTIVATION_EMAIL": True,
+    "ACTIVATION_URL": "activate/{uid}/{token}",
+    "SEND_CONFIRMATION_EMAIL": True,
+    "PASSWORD_CHANGED_EMAIL_CONFIRMATION": True,
+    "USERNAME_CHANGED_EMAIL_CONFIRMATION": True,
+    "SET_USERNAME_RETYPE": True,
+    "SET_PASSWORD_RETYPE": True,
+    "USERNAME_RESET_CONFIRM_URL": "email/reset/confirm/{uid}/{token}",
+    "PASSWORD_RESET_CONFIRM_URL": "password/reset/confirm/{uid}/{token}",
     "SERIALIZERS": {
-        "user_create": "api.accounts.serializers.UserSerializer",
+        "user_create": "api.accounts.serializers.UserCreateSerializer",
         "user": "api.accounts.serializers.UserSerializer",
         "current_user": "api.accounts.serializers.UserSerializer",
     },
-
-    'EMAIL': {
-        'activation': 'api.accounts.email.ActivationEmail',
-        'confirmation': 'api.accounts.email.ConfirmationEmail',
-        'password_reset': 'api.accounts.email.PasswordResetEmail',
-        'username_reset': 'api.accounts.email.UsernameResetEmail',
-        'password_changed_confirmation': 'api.accounts.email.PasswordChangedConfirmationEmail',
-        'username_changed_confirmation': 'api.accounts.email.UsernameChangedConfirmationEmail',
+    "EMAIL": {
+        "activation": "api.accounts.email.ActivationEmail",
+        "confirmation": "api.accounts.email.ConfirmationEmail",
+        "password_reset": "api.accounts.email.PasswordResetEmail",
+        "username_reset": "api.accounts.email.UsernameResetEmail",
+        "password_changed_confirmation": "api.accounts.email.PasswordChangedConfirmationEmail",
+        "username_changed_confirmation": "api.accounts.email.UsernameChangedConfirmationEmail",
     },
-
 }
 
 
 # ローカル確認用
-EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
+EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
 
 # 本番環境用
 # EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
-EMAIL_HOST = 'smtp.gmail.com'
-EMAIL_HOST_USER = 'xxx@gmail.com'
-EMAIL_HOST_PASSWORD = 'xxx'
+EMAIL_HOST = "smtp.gmail.com"
+EMAIL_HOST_USER = "xxx@gmail.com"
+EMAIL_HOST_PASSWORD = "xxx"
 EMAIL_PORT = 587
 EMAIL_USE_TLS = True
-DEFAULT_FROM_EMAIL = 'xxx@video-up.com'
+DEFAULT_FROM_EMAIL = "xxx@video-up.com"
 
 
 LOGGING = {

--- a/frontend-react/src/components/Login.jsx
+++ b/frontend-react/src/components/Login.jsx
@@ -106,8 +106,9 @@ const Login = () => {
           ? (window.location.href = "/")
           : (window.location.href = "/login");
         dispatch({ type: FETCH_SUCCESS });
-      } catch {
+      } catch (e) {
         dispatch({ type: ERROR_CATCHED });
+        console.log(e);
       }
     } else {
       try {
@@ -124,8 +125,10 @@ const Login = () => {
           ? (window.location.href = "/")
           : (window.location.href = "/login");
         dispatch({ type: FETCH_SUCCESS });
-      } catch {
+      } catch (e) {
         dispatch({ type: ERROR_CATCHED });
+        console.log(res);
+        console.log(e);
       }
     }
   };


### PR DESCRIPTION
## ユーザー登録時のメアド有効確認、メールアドレス、パスワードの変更APIの実装

### ログイン
ログイン:`/api/auth/jwt/create/`
### ユーザー登録時のメアド有効確認APIエンドポイント
ユーザー仮登録:`/api/auth/users/`
ユーザー本登録:`/api/auth/users/activation/`
ユーザー本登録再送信:`/api/auth/users/resend_activation/`

### メールアドレス、パスワードの変更APIエンドポイント
メールアドレス変更:`/api/auth/users/rest_email/`
メールアドレス変更確認:`/api/auth/users/reset_email_confirm/`
パスワード変更:`/api/auth/users/set_password/`
パスワードリセット:`/api/auth/users/reset_password/`
パスワード変更確認:`/api/auth/users/reset_password_confirm/`